### PR TITLE
Fix club image size

### DIFF
--- a/components/club-or-department/club-or-department.tsx
+++ b/components/club-or-department/club-or-department.tsx
@@ -31,12 +31,12 @@ const ClubOrDepartmentPage: FC<ClubOrDepartmentProps> = ({
           </Link>
         </div>
         <Image
-          className="w-full h-auto rounded-[20px] object-cover order-first lg:order-last"
+          className="mx-auto rounded-[20px] object-cover order-first lg:order-last"
           src={image}
           alt="image"
           quality={100}
-          width={500}
-          height={500}
+          width={400}
+          height={400}
         />
       </section>
       {projects.length > 0 && (


### PR DESCRIPTION
#253 Fix bug with too large club image on student associations page when screens width is less than 1023px.